### PR TITLE
Fix outer tab memory use

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1511,7 +1511,10 @@ namespace SD.Yuzu
                         vm.SelectedTab.SelectedInnerTab.IsContentReady = false;
                     }
                     
-                    LoadImagesForTab(vm.SelectedTab);
+                    if (!vm.SelectedTab.HasLoadedImages)
+                    {
+                        LoadImagesForTab(vm.SelectedTab);
+                    }
                     
                     // 内側タブの変更も監視するためにイベントハンドラーを設定
                     vm.SelectedTab.PropertyChanged -= OuterTab_PropertyChanged;
@@ -1592,6 +1595,9 @@ namespace SD.Yuzu
             {
                 LoadImagesForInnerTab(innerTab);
             }
+
+            // 画像を読み込んだことを記録
+            tab.HasLoadedImages = true;
         }
 
         private void LoadImagesForInnerTab(TabItemViewModel innerTab)

--- a/TabItemViewModel.cs
+++ b/TabItemViewModel.cs
@@ -526,6 +526,14 @@ namespace SD.Yuzu
             set { _isContentReady = value; OnPropertyChanged(nameof(IsContentReady)); }
         }
 
+        // 外側タブの画像読み込み状態を示すフラグ（保存対象外）
+        private bool _hasLoadedImages = false;
+        public bool HasLoadedImages
+        {
+            get => _hasLoadedImages;
+            set { _hasLoadedImages = value; OnPropertyChanged(nameof(HasLoadedImages)); }
+        }
+
         // Steps変更機能関連のプロパティ
         private long _bulkStepsValue = 8;
         public long BulkStepsValue
@@ -823,6 +831,9 @@ namespace SD.Yuzu
                 EnableRandomResolution = dto.EnableRandomResolution,
                 GenerateButtonText = "Generate" // 復元時は常に"Generate"に設定
             };
+
+            // 画像読み込みフラグは復元後に初期化
+            vm.HasLoadedImages = false;
             
             // 復元フラグを無効にして、以降は通常動作にする
             vm._isRestoring = false;


### PR DESCRIPTION
## Summary
- prevent outer tab from reloading images each switch
- mark when images were loaded in TabItemViewModel

## Testing
- `dotnet build SD.Yuzu.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851378aaed88324a36f7c6ebc856478